### PR TITLE
Change brightness values' type to match library changes & added cheerlights

### DIFF
--- a/cheerlights/.gitignore
+++ b/cheerlights/.gitignore
@@ -1,0 +1,1 @@
+cheerlights

--- a/cheerlights/Dockerfile
+++ b/cheerlights/Dockerfile
@@ -1,0 +1,21 @@
+FROM resin/rpi-raspbian
+
+# Install Go 1.7.5 and enough of a build-chain to build wiringpi (in C)
+RUN apt-get update && \
+    apt-get install -qy build-essential wiringpi git curl ca-certificates && \
+    curl -sSLO https://storage.googleapis.com/golang/go1.7.5.linux-armv6l.tar.gz && \
+	mkdir -p /usr/local/go && \
+	tar -xvf go1.7.5.linux-armv6l.tar.gz -C /usr/local/go/ --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin/
+ENV GOPATH=/go/
+
+RUN mkdir -p /go/src/github.com/alexellis/blinkt_go_examples/cheerlights
+WORKDIR /go/src/github.com/alexellis/blinkt_go_examples/cheerlights
+
+COPY app.go cheerlights.go	./
+RUN go get -d -v
+
+RUN go build
+
+CMD ["./cheerlights"]

--- a/cheerlights/README.md
+++ b/cheerlights/README.md
@@ -1,0 +1,4 @@
+## Cheerlights
+
+Changes all the LEDs to the colour specified by the Cheerlights IoT feed.  Tweet #cheerlights <colour>
+

--- a/cheerlights/app.go
+++ b/cheerlights/app.go
@@ -16,21 +16,12 @@ func main() {
 	Delay(100)
 
 	for {
-		num := getAstronautCount()
 
-		r := 150
-		g := 0
-		b := 0
+		r, g, b := getCheerlightColours()
+
 		blinkt.Clear()
-
-		for pixel := 0; pixel < num; pixel++ {
-			blinkt.SetPixel(pixel, r, g, b)
-			blinkt.Show()
-			Delay(100)
-		}
-
+		blinkt.SetAll(r, g, b)
+		blinkt.Show()
 		Delay(checkPeriodSeconds * 1000)
 	}
-	blinkt.Clear()
-	blinkt.Show()
 }

--- a/cheerlights/cheerlights.go
+++ b/cheerlights/cheerlights.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type cheerlight struct {
+	Colour string `json:"field2"`
+}
+
+func getRGBFromColour(hexString string) (int, int, int) {
+	//strip off the hash and decode the remaining hex value
+	hexCol, _ := hex.DecodeString(strings.TrimPrefix(hexString, "#"))
+	//return the ints representing rgb
+	return int(hexCol[0]), int(hexCol[1]), int(hexCol[2])
+}
+
+func getCheerlightColours() (int, int, int) {
+	var netClient = &http.Client{
+		Timeout: time.Second * 3,
+	}
+	resp, getErr := netClient.Get("http://api.thingspeak.com/channels/1417/field/2/last.json")
+	if getErr != nil {
+		log.Panic(getErr)
+	}
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		log.Panic(getErr)
+	}
+
+	result := cheerlight{}
+	parseErr := json.Unmarshal(body, &result)
+	if parseErr != nil {
+		log.Panic("Can't parse response")
+		return 0, 0, 0
+	}
+
+	return getRGBFromColour(result.Colour)
+
+}

--- a/cputemp/app.go
+++ b/cputemp/app.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	. "github.com/alexellis/blinkt_go"
-	"os/exec"
-	"strings"
 	"bytes"
 	"fmt"
+	"os/exec"
 	"strconv"
+	"strings"
+
+	. "github.com/alexellis/blinkt_go"
 )
 
 func getTemperature() float64 {
@@ -20,29 +21,29 @@ func getTemperature() float64 {
 	temp := out.String()
 
 	//temp=35.8'C
-	tempVal := temp[strings.Index(temp, "=") + 1 : len(temp) - 3 ]
+	tempVal := temp[strings.Index(temp, "=")+1 : len(temp)-3]
 	celcius, _ := strconv.ParseFloat(tempVal, 64)
 	return celcius
 }
 
 func min(x float64, y float64) float64 {
-    if x < y {
-        return x
-    }
-    return y
+	if x < y {
+		return x
+	}
+	return y
 }
 
 func showGraph(bl *Blinkt, v float64, r int, g int, b int) {
 	v = v * 8
-	one:=float64(1.0)
+	one := float64(1.0)
 
-	for i:=0; i< 8; i++ {
+	for i := 0; i < 8; i++ {
 		if v < 0 {
 			r, g, b = 0, 0, 0
 		} else {
-    			r = int(float64(r) * min(v, one))
-    			g = int(float64(g) * min(v, one))
-    			b = int(float64(b) * min(v, one))
+			r = int(float64(r) * min(v, one))
+			g = int(float64(g) * min(v, one))
+			b = int(float64(b) * min(v, one))
 		}
 		bl.SetPixel(i, r, g, b)
 		v = v - 1
@@ -51,7 +52,8 @@ func showGraph(bl *Blinkt, v float64, r int, g int, b int) {
 }
 
 func main() {
-	blinkt := NewBlinkt(20)
+	brightness := 0.5
+	blinkt := NewBlinkt(brightness)
 	blinkt.Setup()
 	blinkt.SetClearOnExit(true)
 

--- a/progress/app.go
+++ b/progress/app.go
@@ -3,7 +3,7 @@ package main
 import . "github.com/alexellis/blinkt_go"
 
 func main() {
-	brightness := 25
+	brightness := 0.5
 	blinkt := NewBlinkt(brightness)
 
 	blinkt.SetClearOnExit(true)

--- a/random_blink/Dockerfile
+++ b/random_blink/Dockerfile
@@ -1,0 +1,21 @@
+FROM resin/rpi-raspbian
+
+# Install Go 1.7.5 and enough of a build-chain to build wiringpi (in C)
+RUN apt-get update && \
+    apt-get install -qy build-essential wiringpi git curl ca-certificates && \
+    curl -sSLO https://storage.googleapis.com/golang/go1.7.5.linux-armv6l.tar.gz && \
+	mkdir -p /usr/local/go && \
+	tar -xvf go1.7.5.linux-armv6l.tar.gz -C /usr/local/go/ --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin/
+ENV GOPATH=/go/
+
+RUN mkdir -p /go/src/github.com/alexellis/blinkt_go_examples/random_blink
+WORKDIR /go/src/github.com/alexellis/blinkt_go_examples/random_blink
+
+COPY app.go	.
+RUN go get -d -v
+
+RUN go build
+
+CMD ["./random_blink"]

--- a/random_blink/app.go
+++ b/random_blink/app.go
@@ -32,7 +32,7 @@ func isIn(s *[]int, e *int) bool {
 
 func main() {
 
-	brightness := 25
+	brightness := 0.5
 	blinkt := NewBlinkt(brightness)
 
 	blinkt.SetClearOnExit(true)

--- a/random_blink_colours/Dockerfile
+++ b/random_blink_colours/Dockerfile
@@ -1,0 +1,21 @@
+FROM resin/rpi-raspbian
+
+# Install Go 1.7.5 and enough of a build-chain to build wiringpi (in C)
+RUN apt-get update && \
+    apt-get install -qy build-essential wiringpi git curl ca-certificates && \
+    curl -sSLO https://storage.googleapis.com/golang/go1.7.5.linux-armv6l.tar.gz && \
+	mkdir -p /usr/local/go && \
+	tar -xvf go1.7.5.linux-armv6l.tar.gz -C /usr/local/go/ --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin/
+ENV GOPATH=/go/
+
+RUN mkdir -p /go/src/github.com/alexellis/blinkt_go_examples/random_blink_colours
+WORKDIR /go/src/github.com/alexellis/blinkt_go_examples/random_blink_colours
+
+COPY app.go	.
+RUN go get -d -v
+
+RUN go build
+
+CMD ["./random_blink_colours"]

--- a/random_blink_colours/app.go
+++ b/random_blink_colours/app.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-	brightness := 25
+	brightness := 0.5
 	blinkt := NewBlinkt(brightness)
 
 	blinkt.SetClearOnExit(true)

--- a/resistor_clock/Dockerfile
+++ b/resistor_clock/Dockerfile
@@ -1,0 +1,21 @@
+FROM resin/rpi-raspbian
+
+# Install Go 1.7.5 and enough of a build-chain to build wiringpi (in C)
+RUN apt-get update && \
+    apt-get install -qy build-essential wiringpi git curl ca-certificates && \
+    curl -sSLO https://storage.googleapis.com/golang/go1.7.5.linux-armv6l.tar.gz && \
+	mkdir -p /usr/local/go && \
+	tar -xvf go1.7.5.linux-armv6l.tar.gz -C /usr/local/go/ --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin/
+ENV GOPATH=/go/
+
+RUN mkdir -p /go/src/github.com/alexellis/blinkt_go_examples/resistor_clock
+WORKDIR /go/src/github.com/alexellis/blinkt_go_examples/resistor_clock
+
+COPY app.go	.
+RUN go get -d -v
+
+RUN go build
+
+CMD ["./resistor_clock"]

--- a/resistor_clock/app.go
+++ b/resistor_clock/app.go
@@ -15,7 +15,7 @@ func breakOut(colours []int) (int, int, int) {
 
 func main() {
 
-	brightness := 25
+	brightness := 0.5
 	blinkt := NewBlinkt(brightness)
 
 	blinkt.SetClearOnExit(true)

--- a/solid_colours/Dockerfile
+++ b/solid_colours/Dockerfile
@@ -1,0 +1,21 @@
+FROM resin/rpi-raspbian
+
+# Install Go 1.7.5 and enough of a build-chain to build wiringpi (in C)
+RUN apt-get update && \
+    apt-get install -qy build-essential wiringpi git curl ca-certificates && \
+    curl -sSLO https://storage.googleapis.com/golang/go1.7.5.linux-armv6l.tar.gz && \
+	mkdir -p /usr/local/go && \
+	tar -xvf go1.7.5.linux-armv6l.tar.gz -C /usr/local/go/ --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin/
+ENV GOPATH=/go/
+
+RUN mkdir -p /go/src/github.com/alexellis/blinkt_go_examples/solid_colours
+WORKDIR /go/src/github.com/alexellis/blinkt_go_examples/solid_colours
+
+COPY app.go	.
+RUN go get -d -v
+
+RUN go build
+
+CMD ["./solid_colours"]

--- a/solid_colours_brightness/.gitignore
+++ b/solid_colours_brightness/.gitignore
@@ -1,0 +1,1 @@
+solid_colours_brightness

--- a/solid_colours_brightness/Dockerfile
+++ b/solid_colours_brightness/Dockerfile
@@ -1,0 +1,21 @@
+FROM resin/rpi-raspbian
+
+# Install Go 1.7.5 and enough of a build-chain to build wiringpi (in C)
+RUN apt-get update && \
+    apt-get install -qy build-essential wiringpi git curl ca-certificates && \
+    curl -sSLO https://storage.googleapis.com/golang/go1.7.5.linux-armv6l.tar.gz && \
+	mkdir -p /usr/local/go && \
+	tar -xvf go1.7.5.linux-armv6l.tar.gz -C /usr/local/go/ --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin/
+ENV GOPATH=/go/
+
+RUN mkdir -p /go/src/github.com/alexellis/blinkt_go_examples/solid_colours_brightness
+WORKDIR /go/src/github.com/alexellis/blinkt_go_examples/solid_colours_brightness
+
+COPY app.go	.
+RUN go get -d -v
+
+RUN go build
+
+CMD ["./solid_colours_brightness"]

--- a/solid_colours_brightness/README.md
+++ b/solid_colours_brightness/README.md
@@ -1,0 +1,3 @@
+## solid_colours_brightness
+
+An elaboration of the `solid_colours` example to demonstrate how to set brightness throughout runtime.

--- a/solid_colours_brightness/app.go
+++ b/solid_colours_brightness/app.go
@@ -20,11 +20,11 @@ func main() {
 		step = step % 3
 		switch step {
 		case 0:
-			blinkt.SetAll(128, 0, 0)
+			blinkt.SetAll(128, 0, 0).SetBrightness(0.5)
 		case 1:
-			blinkt.SetAll(0, 128, 0)
+			blinkt.SetBrightness(0.1).SetAll(0, 128, 0)
 		case 2:
-			blinkt.SetAll(0, 0, 128)
+			blinkt.SetAll(0, 0, 128).SetBrightness(0.9)
 		}
 
 		step++

--- a/spacecount/Dockerfile
+++ b/spacecount/Dockerfile
@@ -1,0 +1,21 @@
+FROM resin/rpi-raspbian
+
+# Install Go 1.7.5 and enough of a build-chain to build wiringpi (in C)
+RUN apt-get update && \
+    apt-get install -qy build-essential wiringpi git curl ca-certificates && \
+    curl -sSLO https://storage.googleapis.com/golang/go1.7.5.linux-armv6l.tar.gz && \
+	mkdir -p /usr/local/go && \
+	tar -xvf go1.7.5.linux-armv6l.tar.gz -C /usr/local/go/ --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin/
+ENV GOPATH=/go/
+
+RUN mkdir -p /go/src/github.com/alexellis/blinkt_go_examples/spacecount
+WORKDIR /go/src/github.com/alexellis/blinkt_go_examples/spacecount
+
+COPY app.go space.go	./
+RUN go get -d -v
+
+RUN go build
+
+CMD ["./spacecount"]

--- a/sysfs/cheerlights/.gitignore
+++ b/sysfs/cheerlights/.gitignore
@@ -1,0 +1,1 @@
+cheerlights

--- a/sysfs/cheerlights/README.md
+++ b/sysfs/cheerlights/README.md
@@ -1,0 +1,5 @@
+## Cheerlights
+
+Changes all the LEDs to the colour specified by the Cheerlights IoT feed.  Tweet #cheerlights <colour>
+
+This version of uses sysfs so it will work with Docker Swarm.

--- a/sysfs/cheerlights/app.go
+++ b/sysfs/cheerlights/app.go
@@ -1,0 +1,27 @@
+package main
+
+import . "github.com/alexellis/blinkt_go/sysfs"
+
+func main() {
+
+	brightness := 0.5
+	blinkt := NewBlinkt(brightness)
+
+	checkPeriodSeconds := 60
+
+	blinkt.SetClearOnExit(true)
+
+	blinkt.Setup()
+
+	Delay(100)
+
+	for {
+
+		r, g, b := getCheerlightColours()
+
+		blinkt.Clear()
+		blinkt.SetAll(r, g, b)
+		blinkt.Show()
+		Delay(checkPeriodSeconds * 1000)
+	}
+}

--- a/sysfs/cheerlights/cheerlights.go
+++ b/sysfs/cheerlights/cheerlights.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type cheerlight struct {
+	Colour string `json:"field2"`
+}
+
+func getRGBFromColour(hexString string) (int, int, int) {
+	//strip off the hash and decode the remaining hex value
+	hexCol, _ := hex.DecodeString(strings.TrimPrefix(hexString, "#"))
+	//return the ints representing rgb
+	return int(hexCol[0]), int(hexCol[1]), int(hexCol[2])
+}
+
+func getCheerlightColours() (int, int, int) {
+	var netClient = &http.Client{
+		Timeout: time.Second * 3,
+	}
+	resp, getErr := netClient.Get("http://api.thingspeak.com/channels/1417/field/2/last.json")
+	if getErr != nil {
+		log.Panic(getErr)
+	}
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		log.Panic(getErr)
+	}
+
+	result := cheerlight{}
+	parseErr := json.Unmarshal(body, &result)
+	if parseErr != nil {
+		log.Panic("Can't parse response")
+		return 0, 0, 0
+	}
+
+	return getRGBFromColour(result.Colour)
+
+}

--- a/sysfs/progress/app.go
+++ b/sysfs/progress/app.go
@@ -3,7 +3,7 @@ package main
 import . "github.com/alexellis/blinkt_go/sysfs"
 
 func main() {
-	brightness := 25
+	brightness := 0.5
 	blinkt := NewBlinkt(brightness)
 
 	blinkt.SetClearOnExit(true)

--- a/sysfs/redis_view/app.go
+++ b/sysfs/redis_view/app.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/redis.v5"
 	"os"
 )
 
@@ -32,7 +31,7 @@ func newClient() *redis.Client {
 }
 
 func main() {
-	brightness := 25
+	brightness := 0.5
 	blinkt := NewBlinkt(brightness)
 	blinkt.SetClearOnExit(true)
 
@@ -52,7 +51,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		if(msg.Channel=="lights") {
+		if msg.Channel == "lights" {
 			ledMsg := LedMsg{}
 			jsonErr := json.Unmarshal([]byte(msg.Payload), &ledMsg)
 			if jsonErr != nil {


### PR DESCRIPTION
I've also added a `Dockerfile` to each example following the initial example you created for progress.

Reviewing below it looks as though its highlighting a few changes in CPUtemp; these are mostly due to VSCode beautifying on save, the only material change should be the initial brightness value.