### PR TITLE
Cheerlights - Added refresh env var checking it exists and is of correct type

### DIFF
--- a/cheerlights/app.go
+++ b/cheerlights/app.go
@@ -1,13 +1,30 @@
 package main
 
-import . "github.com/alexellis/blinkt_go/sysfs"
+import (
+	"os"
+	"strconv"
+
+	. "github.com/alexellis/blinkt_go/sysfs"
+)
+
+func getEnv(envVar string, assumed int) int {
+	if value, exists := os.LookupEnv(envVar); exists {
+		if period, err := strconv.Atoi(value); err == nil {
+			return period
+		}
+	}
+	return assumed
+}
+
+const defaultRefreshSeconds = 60
+const envRefreshSeconds = "refresh_seconds"
 
 func main() {
 
 	brightness := 0.5
 	blinkt := NewBlinkt(brightness)
 
-	checkPeriodSeconds := 60
+	checkPeriodSeconds := getEnv(envRefreshSeconds, defaultRefreshSeconds)
 
 	blinkt.SetClearOnExit(true)
 

--- a/cheerlights/cheerlights.go
+++ b/cheerlights/cheerlights.go
@@ -26,15 +26,23 @@ func getCheerlightColours() (int, int, int) {
 		Timeout: time.Second * 3,
 	}
 	resp, getErr := netClient.Get("http://api.thingspeak.com/channels/1417/field/2/last.json")
+
 	if getErr != nil {
 		log.Panic(getErr)
 	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
 	body, readErr := ioutil.ReadAll(resp.Body)
+
 	if readErr != nil {
 		log.Panic(getErr)
 	}
 
 	result := cheerlight{}
+
 	parseErr := json.Unmarshal(body, &result)
 	if parseErr != nil {
 		log.Panic("Can't parse response")


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

Added ability to configure the refresh period though an environment variable: `refresh_seconds`

Tested by adding a debug print either side of the `Delay` call.

Default (60 Seconds)
```
docker run --name iot --restart=always --privileged -ti cheerlights 
Press Control + C to stop
1510514316
(Delay)
1510514376
--------------
1510514377
(Delay)
1510514437
--------------
1510514438
(Delay)
1510514498
```

With envVar set to 30:
```
docker run --name iot --restart=always --privileged -ti -e "cheerlightsCheckSeconds=30" cheerlights 
Press Control + C to stop
1510514070
(Delay)
1510514100
--------------
1510514101
(Delay)
1510514131
--------------
1510514132
(Delay)
1510514162
```

With non-integer envVar (defaults to 60 seconds):
```
docker run --name iot --restart=always --privileged -ti -e "cheerlightsCheckSeconds=FRED" cheerlights 
Press Control + C to stop
1510514505
(Delay)
1510514565
--------------
1510514566
(Delay)
1510514626
--------------
1510514627
(Delay)
1510514687
```